### PR TITLE
chore: hold TypeScript at v6 in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,11 @@ updates:
       - dependency-name: "eslint"
         update-types:
           - version-update:semver-major
+      # TypeScript 7 (native compiler) is not yet supported by @astrojs/check,
+      # whose peer dependency caps TypeScript at ^5 || ^6. See PR #373.
+      - dependency-name: "typescript"
+        update-types:
+          - version-update:semver-major
     groups:
       all:
         update-types:


### PR DESCRIPTION
TypeScript 7 ships the native (Go) compiler, which @astrojs/check does not yet support — its peer dependency caps TypeScript at ^5 || ^6, so npm ci fails to resolve and astro check crashes at runtime. Ignore TypeScript major updates until the Astro toolchain supports v7.
